### PR TITLE
Include navbar dropdown event handler in Angular2_CLI_Starter

### DIFF
--- a/Angular2_CLI_Starter/src/app/layouts/full-layout.component.ts
+++ b/Angular2_CLI_Starter/src/app/layouts/full-layout.component.ts
@@ -5,8 +5,21 @@ import { Component, OnInit }            from '@angular/core';
     templateUrl: './full-layout.component.html'
 })
 export class FullLayoutComponent implements OnInit {
-
+    
     constructor() { }
+
+    public disabled:boolean = false;
+    public status:{isopen:boolean} = {isopen: false};
+
+    public toggled(open:boolean):void {
+        console.log('Dropdown is now: ', open);
+    }
+
+    public toggleDropdown($event:MouseEvent):void {
+        $event.preventDefault();
+        $event.stopPropagation();
+        this.status.isopen = !this.status.isopen;
+    }
 
     ngOnInit(): void {}
 }


### PR DESCRIPTION
Awesome template, thanks for sharing!

While using the Angular2_CLI_Starter project to create my admin panel, I noticed that the dropdown event handler on `full-layout.component.ts` for the navbar was missing. Using the full project as an example, I ported the event handler code over to the starter project.

I'm not sure if you left this out intentionally or if it was just overlooked. Feel free to merge if you see fit.