### PR TITLE
fixed typo that prevented vue-strap Modal loading

### DIFF
--- a/Vue_Full_Project/src/views/components/Modals.vue
+++ b/Vue_Full_Project/src/views/components/Modals.vue
@@ -115,7 +115,7 @@
 </template>
 
 <script>
-import modal from 'vue-strap/src/modal'
+import modal from 'vue-strap/src/Modal'
 
 export default {
   name: 'modals',


### PR DESCRIPTION
Fixed dependency issue that was due to small letter in src/views/components/Modals.vue
( `import modal from 'vue-strap/src/Modal'` , was previously `modal` )