### PR TITLE
Remove useless Breadcrumb component property "separator" for VueJS

### DIFF
--- a/Vue_Full_Project/src/components/Breadcrumb.vue
+++ b/Vue_Full_Project/src/components/Breadcrumb.vue
@@ -13,8 +13,7 @@ export default {
       type: Array,
       required: true,
       default: () => []
-    },
-    separator: String
+    }
   },
   methods: {
     isLast (index) {

--- a/Vue_Starter/src/components/Breadcrumb.vue
+++ b/Vue_Starter/src/components/Breadcrumb.vue
@@ -13,8 +13,7 @@ export default {
       type: Array,
       required: true,
       default: () => []
-    },
-    separator: String
+    }
   },
   methods: {
     isLast (index) {


### PR DESCRIPTION
This property is not used and the separator ("/") is set by bootstrap via the CSS