### PR TITLE
Fix sass callout

### DIFF
--- a/Static_Full_Project_GULP/scss/core/_callout.scss
+++ b/Static_Full_Project_GULP/scss/core/_callout.scss
@@ -16,6 +16,16 @@
     float: right;
     width: 50%;
   }
+  
+  @each $color, $value in $theme-colors {
+    &.callout-#{$color} {
+      border-left-color: $value;
+
+      h4 {
+        color: $value;
+      }
+    }
+  }
 }
 
 .callout-bordered {
@@ -41,15 +51,5 @@
 
   h4 {
     color: $text-muted;
-  }
-}
-
-@each $color, $value in $theme-colors {
-  &.callout-#{$color} {
-    border-left-color: $value;
-
-    h4 {
-      color: $value;
-    }
   }
 }

--- a/Static_Starter_GULP/scss/core/_callout.scss
+++ b/Static_Starter_GULP/scss/core/_callout.scss
@@ -16,6 +16,16 @@
     float: right;
     width: 50%;
   }
+  
+  @each $color, $value in $theme-colors {
+    &.callout-#{$color} {
+      border-left-color: $value;
+
+      h4 {
+        color: $value;
+      }
+    }
+  }
 }
 
 .callout-bordered {
@@ -44,12 +54,3 @@
   }
 }
 
-@each $color, $value in $theme-colors {
-  &.callout-#{$color} {
-    border-left-color: $value;
-
-    h4 {
-      color: $value;
-    }
-  }
-}


### PR DESCRIPTION
Sass nesting is broken with the Ruby Sass compiler. Refactored nesting to match (working) RTL nesting.

Fixes #249.